### PR TITLE
Switch to SMTP for Gmail sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Ferramenta de linha de comando para enviar e-mails personalizados via Gmail a pa
 ## Pré-requisitos
 
 1. **Python 3.10+** instalado.
-2. Criar um projeto no [Google Cloud Console](https://console.cloud.google.com/) e habilitar a API do Gmail.
-3. Configurar uma credencial do tipo *Desktop* e baixar o arquivo `credentials.json` para a raiz do projeto.
-4. Instalar as dependências:
+2. Uma conta Gmail com [verificação em duas etapas](https://myaccount.google.com/security) habilitada e uma [senha de app](https://support.google.com/accounts/answer/185833) gerada especificamente para o envio automatizado.
+3. Instalar as dependências:
 
    ```bash
    python -m venv .venv
@@ -46,19 +45,30 @@ python email_sender.py leads.xlsx \
   --body-template "$(cat template.html)"
 ```
 
-Na primeira execução será aberta uma janela do navegador solicitando que autorize o acesso à sua conta Gmail. O token de acesso será salvo no arquivo `token.json`.
+Ao executar o comando, o script solicitará a senha SMTP (recomenda-se usar a senha de app). Você também pode informar as credenciais via linha de comando:
+
+```bash
+python email_sender.py leads.xlsx \
+  --sender "seu-email@gmail.com" \
+  --smtp-user "seu-email@gmail.com" \
+  --smtp-password "sua-senha-de-app" \
+  --subject-template "Plano funerário especial para {{ nome }}" \
+  --body-template "$(cat template.html)"
+```
+
+As mensagens são enviadas utilizando `smtplib.SMTP_SSL` diretamente contra `smtp.gmail.com:465`, portanto não é necessário configurar nenhum projeto no Google Cloud.
 
 ### Opções adicionais
 
 - `--sheet`: define o nome da aba da planilha (caso não seja a primeira).
-- `--credentials`: caminho alternativo para o `credentials.json`.
-- `--token`: caminho alternativo para o `token.json`.
+- `--smtp-user`: usuário SMTP a ser autenticado (por padrão é o mesmo informado em `--sender`).
+- `--smtp-password`: senha ou senha de app a ser utilizada (se omitido, será solicitado via prompt seguro).
 - `--dry-run`: apenas renderiza as mensagens sem enviá-las.
 - `--log-level`: ajusta o nível de log (padrão: `INFO`).
 
 ## Segurança
 
-- Nunca compartilhe o conteúdo de `credentials.json` ou `token.json`.
+- Prefira utilizar senhas de app em vez da senha principal da conta Gmail.
 - Guarde a planilha com os dados sensíveis em local seguro.
 
 ## Licença

--- a/email_sender.py
+++ b/email_sender.py
@@ -8,52 +8,24 @@ The script expects a spreadsheet containing at least the columns:
 Extra columns are available as template variables when rendering the
 message subject and body.
 
-Authentication is performed through the Gmail API using OAuth2. The
-first run will prompt for authentication in the browser and persist
-the resulting token in ``token.json``.
+Authentication is performed using Gmail's SMTP server over SSL. The
+user must provide their Gmail username and password (or app password).
 """
 from __future__ import annotations
 
 import argparse
-import base64
+import getpass
 import logging
+import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
 from jinja2 import Template
 
-SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
-
 logger = logging.getLogger(__name__)
-
-
-def authenticate(credentials_path: Path, token_path: Path) -> Credentials:
-    """Authenticate against Gmail, creating or refreshing a token."""
-    creds = None
-    if token_path.exists():
-        creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
-
-    if creds and creds.valid:
-        return creds
-
-    if creds and creds.expired and creds.refresh_token:
-        logger.info("Refreshing Gmail access token...")
-        creds.refresh(Request())
-    else:
-        logger.info("Starting OAuth flow. Follow the browser instructions.")
-        flow = InstalledAppFlow.from_client_secrets_file(str(credentials_path), SCOPES)
-        creds = flow.run_local_server(port=0)
-
-    token_path.write_text(creds.to_json())
-    logger.info("Saved refreshed token to %s", token_path)
-    return creds
 
 
 def load_contacts(excel_path: Path, sheet: str | None = None) -> pd.DataFrame:
@@ -75,8 +47,8 @@ def render_template(template: str, context: Dict[str, str]) -> str:
     return Template(template).render(**context)
 
 
-def create_message(sender: str, to: str, subject: str, body_html: str) -> Dict[str, str]:
-    """Compose a MIME email ready for Gmail API."""
+def create_message(sender: str, to: str, subject: str, body_html: str) -> MIMEMultipart:
+    """Compose a MIME email message."""
     message = MIMEMultipart("alternative")
     message["To"] = to
     message["From"] = sender
@@ -84,13 +56,11 @@ def create_message(sender: str, to: str, subject: str, body_html: str) -> Dict[s
 
     part_html = MIMEText(body_html, "html", "utf-8")
     message.attach(part_html)
-
-    raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
-    return {"raw": raw_message}
+    return message
 
 
 def send_messages(
-    service,
+    smtp: Optional[smtplib.SMTP],
     sender: str,
     contacts: Iterable[Dict[str, str]],
     subject_template: str,
@@ -98,36 +68,46 @@ def send_messages(
     dry_run: bool = False,
 ) -> List[str]:
     """Send rendered messages to all contacts."""
-    sent_ids: List[str] = []
+    if not dry_run and smtp is None:
+        raise ValueError("SMTP connection is required when not running in dry-run mode.")
+
+    sent_to: List[str] = []
     for row in contacts:
         context = {k: str(v) if pd.notna(v) else "" for k, v in row.items()}
         subject = render_template(subject_template, context)
         body = render_template(body_template, context)
-        message = create_message(sender=sender, to=context["email"], subject=subject, body_html=body)
+        message = create_message(
+            sender=sender,
+            to=context["email"],
+            subject=subject,
+            body_html=body,
+        )
 
         logger.info("Prepared email to %s with subject '%s'", context["email"], subject)
         if dry_run:
             logger.debug("Dry run enabled, skipping send for %s", context["email"])
             continue
 
-        sent = (
-            service.users()
-            .messages()
-            .send(userId="me", body=message)
-            .execute()
-        )
-        sent_ids.append(sent.get("id", ""))
-        logger.info("Sent message to %s (id=%s)", context["email"], sent.get("id"))
-    return sent_ids
+        assert smtp is not None  # for type checkers
+        smtp.sendmail(sender, [context["email"]], message.as_string())
+        sent_to.append(context["email"])
+        logger.info("Sent message to %s", context["email"])
+    return sent_to
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Send Gmail messages from an Excel contact list.")
     parser.add_argument("excel", type=Path, help="Path to the Excel file containing contacts.")
     parser.add_argument("--sheet", help="Excel sheet name to read.")
-    parser.add_argument("--credentials", type=Path, default=Path("credentials.json"), help="Path to the OAuth client credentials file.")
-    parser.add_argument("--token", type=Path, default=Path("token.json"), help="Path to the saved OAuth token file.")
     parser.add_argument("--sender", required=True, help="Email address of the sender (must match Gmail account).")
+    parser.add_argument(
+        "--smtp-user",
+        help="SMTP username. Defaults to the sender address if omitted.",
+    )
+    parser.add_argument(
+        "--smtp-password",
+        help="SMTP password or app password. If omitted, it will be requested via prompt.",
+    )
     parser.add_argument("--subject-template", required=True, help="Template for the email subject. Jinja2 placeholders are allowed.")
     parser.add_argument("--body-template", required=True, help="Template for the HTML body. Jinja2 placeholders are allowed.")
     parser.add_argument("--dry-run", action="store_true", help="Render messages without sending them.")
@@ -139,25 +119,37 @@ def main() -> None:
     args = parse_args()
     logging.basicConfig(level=args.log_level.upper(), format="%(levelname)s: %(message)s")
 
-    if not args.credentials.exists():
-        raise FileNotFoundError(
-            f"Credentials file '{args.credentials}' not found. Download it from the Google Cloud console."
-        )
-
-    creds = authenticate(args.credentials, args.token)
-    service = build("gmail", "v1", credentials=creds)
-
     contacts_df = load_contacts(args.excel, args.sheet)
     contacts_records = contacts_df.to_dict(orient="records")
 
-    send_messages(
-        service=service,
-        sender=args.sender,
-        contacts=contacts_records,
-        subject_template=args.subject_template,
-        body_template=args.body_template,
-        dry_run=args.dry_run,
+    smtp_user = args.smtp_user or args.sender
+
+    if args.dry_run:
+        send_messages(
+            smtp=None,
+            sender=args.sender,
+            contacts=contacts_records,
+            subject_template=args.subject_template,
+            body_template=args.body_template,
+            dry_run=True,
+        )
+        return
+
+    smtp_password = args.smtp_password or getpass.getpass(
+        prompt="SMTP password (app password recommended): ",
     )
+
+    logger.info("Connecting to smtp.gmail.com:465 as %s", smtp_user)
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
+        smtp.login(smtp_user, smtp_password)
+        send_messages(
+            smtp=smtp,
+            sender=args.sender,
+            contacts=contacts_records,
+            subject_template=args.subject_template,
+            body_template=args.body_template,
+            dry_run=False,
+        )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 pandas>=2.0
 openpyxl>=3.1
-google-api-python-client>=2.127
-google-auth>=2.27
-google-auth-oauthlib>=1.2
 jinja2>=3.1


### PR DESCRIPTION
## Summary
- replace the Gmail API integration with SMTP over SSL authentication using Gmail credentials supplied via CLI or prompt
- drop Google API dependencies and document the new SMTP-based setup and configuration

## Testing
- python -m compileall email_sender.py

------
https://chatgpt.com/codex/tasks/task_e_68e00fdb88dc8324a5ee5bd340d6de89