### PR TITLE
Add rate limiting and retry logic to email sender

### DIFF
--- a/emaileria/sender.py
+++ b/emaileria/sender.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
+import threading
+import time
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
 
@@ -15,6 +19,139 @@ from .templating import render
 logger = logging.getLogger(__name__)
 
 REQUIRED_KEYS = {"email", "tratamento", "nome"}
+
+_RETRY_DELAYS_SECONDS = [0, 1, 2, 4]
+_MAX_ATTEMPTS = len(_RETRY_DELAYS_SECONDS)
+_TEMPORARY_SMTP_CODES = {"421", "450", "451", "452"}
+
+
+class _TokenBucket:
+    """Simple token bucket implementation for rate limiting."""
+
+    def __init__(self, capacity: int, refill_interval: float = 60.0) -> None:
+        self.capacity = capacity
+        self.refill_interval = refill_interval
+        self.tokens = float(capacity)
+        self.refill_rate = capacity / refill_interval if refill_interval else 0.0
+        self._lock = threading.Lock()
+        self._last_refill = time.monotonic()
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        if elapsed <= 0:
+            return
+        tokens_to_add = elapsed * self.refill_rate
+        if tokens_to_add <= 0:
+            return
+        self.tokens = min(self.capacity, self.tokens + tokens_to_add)
+        self._last_refill = now
+
+    def acquire(self, tokens: int = 1) -> None:
+        if self.capacity <= 0 or self.refill_rate <= 0:
+            return
+
+        while True:
+            with self._lock:
+                self._refill()
+                if self.tokens >= tokens:
+                    self.tokens -= tokens
+                    return
+                missing_tokens = tokens - self.tokens
+                wait_time = missing_tokens / self.refill_rate if self.refill_rate else 0.0
+            if wait_time > 0:
+                logger.debug(
+                    "Rate limit reached, sleeping for %.2fs before sending next email",
+                    wait_time,
+                )
+                time.sleep(wait_time)
+
+
+def _get_rate_limiter() -> Optional[_TokenBucket]:
+    env_value = os.getenv("RATE_LIMIT_PER_MINUTE")
+    if not env_value:
+        return None
+    try:
+        rate_limit = int(env_value)
+    except ValueError:
+        logger.warning(
+            "Invalid RATE_LIMIT_PER_MINUTE value '%s'. Disabling rate limiting.",
+            env_value,
+        )
+        return None
+    if rate_limit <= 0:
+        return None
+    return _TokenBucket(rate_limit)
+
+
+def _is_temporary_error(error: Optional[str]) -> bool:
+    if not error:
+        return False
+
+    lower_error = error.lower()
+    if "timeout" in lower_error or "timed out" in lower_error:
+        return True
+
+    if "4xx" in lower_error:
+        return True
+
+    if re.search(r"\b4\.\d\.\d\b", error):
+        return True
+
+    for match in re.findall(r"\b4\d{2}\b", error):
+        if match in _TEMPORARY_SMTP_CODES:
+            return True
+
+    return False
+
+
+def _safe_send(provider: EmailProvider, message: MIMEMultipart) -> ResultadoEnvio:
+    try:
+        return provider.send(message)
+    except Exception as exc:  # pragma: no cover - provider specific failures
+        to_address = message["To"]
+        logger.exception("Unexpected exception while sending to %s", to_address)
+        return ResultadoEnvio(destinatario=to_address, sucesso=False, erro=str(exc))
+
+
+def _send_with_retries(
+    provider: EmailProvider,
+    message: MIMEMultipart,
+    rate_limiter: Optional[_TokenBucket],
+) -> ResultadoEnvio:
+    to_address = message["To"]
+
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        if rate_limiter is not None:
+            rate_limiter.acquire()
+
+        logger.info("Sending email to %s (attempt %s/%s)", to_address, attempt, _MAX_ATTEMPTS)
+        result = _safe_send(provider, message)
+
+        if result.sucesso:
+            return result
+
+        error_message = result.erro or "Unknown error"
+        logger.error(
+            "Attempt %s to send email to %s failed: %s", attempt, to_address, error_message
+        )
+
+        if attempt == _MAX_ATTEMPTS:
+            return result
+
+        if not _is_temporary_error(result.erro):
+            return result
+
+        sleep_time = _RETRY_DELAYS_SECONDS[attempt]
+        if sleep_time > 0:
+            logger.info(
+                "Retrying email to %s in %ss due to temporary error.",
+                to_address,
+                sleep_time,
+            )
+            time.sleep(sleep_time)
+
+    return ResultadoEnvio(destinatario=to_address, sucesso=False, erro="Unknown error")
 
 
 def _prepare_context(row: Dict[str, object]) -> Dict[str, str]:
@@ -56,6 +193,10 @@ def send_messages(
     if not dry_run and provider is None:
         raise ValueError("provider is required when dry_run is False")
 
+    rate_limiter: Optional[_TokenBucket] = None
+    if not dry_run and provider is not None:
+        rate_limiter = _get_rate_limiter()
+
     results: List[ResultadoEnvio] = []
 
     for row in contacts:
@@ -70,7 +211,7 @@ def send_messages(
             continue
 
         message = _create_message(sender, context["email"], subject, body)
-        result = provider.send(message)
+        result = _send_with_retries(provider, message, rate_limiter)
         results.append(result)
 
     return results


### PR DESCRIPTION
## Summary
- add a token bucket limiter that honors RATE_LIMIT_PER_MINUTE when sending emails
- implement exponential backoff retries for temporary SMTP/timeout errors with detailed logging
- extend sender tests to cover retry behaviour and ensure non-temporary errors skip retries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e02b2379f48324bb84ced84b6b963a