### PR TITLE
Add preview command to CLI

### DIFF
--- a/emaileria/cli.py
+++ b/emaileria/cli.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import getpass
+import html
 import logging
 from pathlib import Path
 
 from . import config
 from .datasource.excel import load_contacts
 from .providers.smtp import SMTPProvider
-from .sender import send_messages
+from .sender import _prepare_context, send_messages
+from .templating import render
 
 
 def _read_template(template: str | None, template_file: Path | None) -> str:
@@ -63,12 +66,235 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _build_preview_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate an HTML gallery preview of rendered emails."
+    )
+    parser.add_argument(
+        "excel",
+        type=Path,
+        help="Path to the Excel/CSV file containing contacts.",
+    )
+    parser.add_argument("--sheet", help="Excel sheet name to read.")
+    parser.add_argument(
+        "--subject-template",
+        required=True,
+        help="Template for the email subject. Jinja2 placeholders are allowed.",
+    )
+    parser.add_argument(
+        "--subject-template-file",
+        type=Path,
+        help="Path to a file containing the subject template. Overrides --subject-template when provided.",
+    )
+    parser.add_argument(
+        "--body-template",
+        required=True,
+        help="Template for the HTML body. Jinja2 placeholders are allowed.",
+    )
+    parser.add_argument(
+        "--body-template-file",
+        type=Path,
+        help="Path to a file containing the body template. Overrides --body-template when provided.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Maximum number of contacts to render in the preview gallery.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR).",
+    )
+    return parser
+
+
 def _load_contacts(path: Path, sheet: str | None) -> list[dict[str, object]]:
     dataframe = load_contacts(path, sheet)
     return dataframe.to_dict(orient="records")
 
 
+def _render_preview(
+    *,
+    contacts: list[dict[str, object]],
+    subject_template: str,
+    body_template: str,
+    limit: int,
+) -> list[tuple[int, str, str, str]]:
+    if limit <= 0:
+        raise ValueError("limit must be a positive integer")
+
+    preview_entries: list[tuple[int, str, str, str]] = []
+    for index, row in enumerate(contacts, start=1):
+        if len(preview_entries) >= limit:
+            break
+        context = _prepare_context(row)
+        subject, body = render(subject_template, body_template, context)
+        preview_entries.append((index, context["email"], subject, body))
+    return preview_entries
+
+
+def _build_preview_html(
+    *,
+    generated_at: _dt.datetime,
+    entries: list[tuple[int, str, str, str]],
+) -> str:
+    formatted_timestamp = generated_at.strftime("%Y-%m-%d %H:%M:%S")
+    navigation_links = "\n        ".join(
+        f"<a href=\"#message-{pos}\">#{pos} - {html.escape(subject or '(sem assunto)')}</a>"
+        for pos, _, subject, _ in entries
+    )
+    navigation_markup = (
+        navigation_links if navigation_links else "<span class=\"empty\">Nenhuma mensagem gerada.</span>"
+    )
+
+    gallery_items = []
+    for pos, recipient, subject, body in entries:
+        gallery_items.append(
+            """
+            <article class="message-card" id="message-{pos}">
+                <header>
+                    <h2>{subject}</h2>
+                    <p class="meta">Destinatário: {recipient}</p>
+                </header>
+                <section class="message-body">{body}</section>
+            </article>
+            """.format(
+                pos=pos,
+                subject=html.escape(subject or "(sem assunto)"),
+                recipient=html.escape(recipient),
+                body=body,
+            )
+        )
+
+    gallery_markup = "\n".join(gallery_items) if gallery_items else "<p>Não há mensagens para pré-visualizar.</p>"
+
+    return f"""<!DOCTYPE html>
+<html lang=\"pt-BR\">
+<head>
+    <meta charset=\"utf-8\" />
+    <title>Pré-visualização de emails</title>
+    <style>
+        body {{
+            font-family: Arial, Helvetica, sans-serif;
+            margin: 2rem;
+            background-color: #f7f7f9;
+            color: #1f1f1f;
+        }}
+        h1 {{
+            font-size: 1.8rem;
+            margin-bottom: 0.5rem;
+        }}
+        .timestamp {{
+            color: #555;
+            margin-bottom: 1.5rem;
+        }}
+        nav {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 2rem;
+        }}
+        nav a {{
+            text-decoration: none;
+            color: #1a73e8;
+            background: #e7f0fe;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.9rem;
+        }}
+        nav a:hover {{
+            background: #d2e3fc;
+        }}
+        nav .empty {{
+            color: #6b6b6b;
+            font-style: italic;
+        }}
+        .gallery {{
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }}
+        .message-card {{
+            background: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            padding: 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }}
+        .message-card h2 {{
+            font-size: 1.2rem;
+            margin: 0;
+        }}
+        .meta {{
+            color: #555;
+            font-size: 0.9rem;
+        }}
+        .message-body {{
+            border-top: 1px solid #e0e0e0;
+            padding-top: 0.75rem;
+        }}
+        .message-body * {{
+            max-width: 100%;
+        }}
+    </style>
+</head>
+<body>
+    <h1>Pré-visualização de emails</h1>
+    <p class=\"timestamp\">Gerado em {formatted_timestamp}</p>
+    <nav>{navigation_markup}</nav>
+    <section class=\"gallery\">{gallery_markup}</section>
+</body>
+</html>
+"""
+
+
+def _write_preview(entries: list[tuple[int, str, str, str]]) -> Path:
+    generated_at = _dt.datetime.now()
+    timestamp = generated_at.strftime("%Y%m%d-%H%M%S")
+    preview_dir = Path("previews") / timestamp
+    preview_dir.mkdir(parents=True, exist_ok=True)
+
+    html_content = _build_preview_html(
+        generated_at=generated_at,
+        entries=entries,
+    )
+    output_file = preview_dir / "index.html"
+    output_file.write_text(html_content, encoding="utf-8")
+    return output_file
+
+
 def main(argv: list[str] | None = None) -> None:
+    if argv and len(argv) > 0 and argv[0] == "preview":
+        preview_parser = _build_preview_parser()
+        preview_args = preview_parser.parse_args(argv[1:])
+
+        logging.basicConfig(
+            level=preview_args.log_level.upper(),
+            format="%(levelname)s: %(message)s",
+        )
+
+        subject_template = _read_template(
+            preview_args.subject_template, preview_args.subject_template_file
+        )
+        body_template = _read_template(
+            preview_args.body_template, preview_args.body_template_file
+        )
+
+        contacts = _load_contacts(preview_args.excel, preview_args.sheet)
+        entries = _render_preview(
+            contacts=contacts,
+            subject_template=subject_template,
+            body_template=body_template,
+            limit=preview_args.limit,
+        )
+        output_path = _write_preview(entries)
+        logging.info("Pré-visualização gerada em %s", output_path)
+        return
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/tests/test_cli_preview.py
+++ b/tests/test_cli_preview.py
@@ -1,0 +1,86 @@
+"""Tests for the preview command in the CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import emaileria.cli as cli_module
+
+
+def _fake_contacts() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "email": "joao@example.com",
+                "tratamento": "Sr.",
+                "nome": "João",
+                "departamento": "Financeiro",
+            },
+            {
+                "email": "maria@example.com",
+                "tratamento": "Sra.",
+                "nome": "Maria",
+                "departamento": "Comercial",
+            },
+        ]
+    )
+
+
+def test_preview_command_generates_gallery(tmp_path, monkeypatch):
+    excel_path = tmp_path / "contacts.xlsx"
+    excel_path.write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    contacts_df = _fake_contacts()
+
+    def fake_load_contacts(path: Path, sheet: str | None = None):
+        assert path == excel_path
+        assert sheet is None
+        return contacts_df.copy()
+
+    monkeypatch.setattr(cli_module, "load_contacts", fake_load_contacts)
+
+    subject_template = "Assunto para {{ nome }}"
+    body_template = "<p>Olá {{ tratamento }} {{ nome }} do {{ departamento }}</p>"
+
+    cli_module.main(
+        [
+            "preview",
+            str(excel_path),
+            "--subject-template",
+            subject_template,
+            "--body-template",
+            body_template,
+            "--limit",
+            "1",
+        ]
+    )
+
+    preview_dirs = list((tmp_path / "previews").iterdir())
+    assert len(preview_dirs) == 1
+    html_file = preview_dirs[0] / "index.html"
+    assert html_file.exists()
+
+    html_content = html_file.read_text(encoding="utf-8")
+    assert "João" in html_content
+    assert "Maria" not in html_content
+    assert "Olá Sr. João" in html_content
+
+
+def test_preview_limit_must_be_positive(monkeypatch):
+    contacts = _fake_contacts().to_dict(orient="records")
+
+    with pytest.raises(ValueError):
+        cli_module._render_preview(
+            contacts=contacts,
+            subject_template="{{ nome }}",
+            body_template="{{ nome }}",
+            limit=0,
+        )


### PR DESCRIPTION
## Summary
- add a preview CLI command that renders the first N email templates into an HTML gallery under previews/<timestamp>
- reuse the existing template rendering pipeline to build navigation-friendly preview pages without sending emails
- cover the new functionality with tests for gallery creation and limit validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e02c7a7b988324ae97384c29e04541