### PR TITLE
Add rate limiting, retries, and delivery reporting

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
-from emaileria.cli import main
+import os
+from typing import List, Optional
 
-__all__ = ["main"]
+from emaileria.cli import main as _cli_main
+
+RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "80"))
+"""Limite padrão de envios por minuto usado pelo token bucket."""
 
 
-if __name__ == "__main__":
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entrypoint that delegates to :mod:`emaileria.cli` after setting defaults."""
+
+    os.environ.setdefault("RATE_LIMIT_PER_MINUTE", str(RATE_LIMIT_PER_MINUTE))
+    _cli_main(argv)
+
+
+__all__ = ["main", "RATE_LIMIT_PER_MINUTE"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
     main()

--- a/emaileria/providers/base.py
+++ b/emaileria/providers/base.py
@@ -15,6 +15,8 @@ class ResultadoEnvio:
     destinatario: str
     sucesso: bool
     erro: str | None = None
+    tentativas: int = 1
+    assunto: str | None = None
 
 
 class EmailProvider(Protocol):


### PR DESCRIPTION
## Summary
- enforce a default per-minute rate limit for sends and record attempt counts in delivery results
- persist send outcomes to CSV and SQLite logs and add a CLI report mode
- expose the default rate limit through the `email_sender.py` entrypoint so command-line usage picks up the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e033406dfc8324ad459dd875cbd1f4