### PR TITLE
Update dry run example to use Excel templates

### DIFF
--- a/examples/send_messages_dry_run.py
+++ b/examples/send_messages_dry_run.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import csv
 import sys
 from pathlib import Path
 
@@ -10,23 +9,25 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+from emaileria.datasource.excel import load_contacts as load_contacts_dataframe
 from emaileria.sender import send_messages
 
 
-def _load_contacts(csv_path: Path) -> list[dict[str, str]]:
-    """Load contacts from a CSV file into a list of dictionaries."""
-    with csv_path.open("r", encoding="utf-8", newline="") as csv_file:
-        reader = csv.DictReader(csv_file)
-        return [dict(row) for row in reader]
+def _load_contacts(excel_path: Path) -> list[dict[str, str]]:
+    """Load contacts from an Excel file into a list of dictionaries."""
+
+    dataframe = load_contacts_dataframe(excel_path)
+    contacts = dataframe.to_dict(orient="records")
+    for contact in contacts:
+        contact.setdefault("data_envio", "")
+    return contacts
 
 
 def main() -> None:
     examples_dir = Path(__file__).resolve().parent
-    data_dir = examples_dir / "readme"
-
-    contacts_path = data_dir / "leads.csv"
-    subject_template_path = data_dir / "template_assunto.txt"
-    body_template_path = data_dir / "template_corpo.html"
+    contacts_path = examples_dir / "leads_exemplo.xlsx"
+    subject_template_path = examples_dir / "assunto_exemplo.txt"
+    body_template_path = examples_dir / "corpo_exemplo.html"
 
     contacts = _load_contacts(contacts_path)
     subject_template = subject_template_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- switch the dry run example to use the XLSX lead list and example templates in the examples folder
- reuse the shared Excel loader so the script supports XLSX inputs and provides defaults for template fields

## Testing
- python examples/send_messages_dry_run.py

------
https://chatgpt.com/codex/tasks/task_e_68e07f80bc5c8324a9a51ed16b784107