### PR TITLE
Refactor GUI to use core email sender API for previews and sends

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -10,15 +10,15 @@ import pandas as pd
 import PySimpleGUI as sg
 
 try:
-    from email_sender import RunParams, run_program
+    from email_sender import RunParams, load_contacts, run_program
 except ImportError as exc:  # pragma: no cover - integração com UI
     IMPORT_ERROR: Optional[Exception] = exc
     RunParams = None  # type: ignore[assignment]
+    load_contacts = None  # type: ignore[assignment]
     run_program = None  # type: ignore[assignment]
 else:
     IMPORT_ERROR = None
 
-from emaileria.datasource.excel import load_contacts
 from emaileria.templating import TemplateRenderingError, render
 
 
@@ -83,6 +83,7 @@ class QueueLogHandler(logging.Handler):
     def __init__(self, message_queue: "queue.Queue[tuple[str, str]]") -> None:
         super().__init__()
         self._queue = message_queue
+        self.setLevel(logging.NOTSET)
         self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - integração com UI
@@ -96,6 +97,175 @@ class QueueLogHandler(logging.Handler):
 def append_log(window: sg.Window, text: str, *, tag: str = "OUT") -> None:
     text_color = "red" if tag == "ERR" else None
     window["-LOG-"].print(text, end="", text_color=text_color)
+
+
+def _prepare_run_params(
+    values: dict[str, object], *, dry_run_override: bool | None = None
+) -> Optional[RunParams]:
+    if RunParams is None:
+        return None
+
+    excel_path = str(values.get("-EXCEL-", "")).strip()
+    if not excel_path:
+        sg.popup_error("Selecione a planilha (XLSX/CSV).")
+        return None
+
+    subject_template = str(values.get("-SUBJECT-", "")).strip()
+    if not subject_template:
+        sg.popup_error("Informe o assunto (template).")
+        return None
+
+    body_html_path = str(values.get("-HTML-", "")).strip()
+    body_html = _read_html_template(body_html_path)
+    if body_html is None:
+        return None
+
+    sheet_value_raw = str(values.get("-SHEET-", "") or "").strip()
+    sheet_value = sheet_value_raw or None
+
+    sender_value = str(values.get("-SENDER-", "")).strip()
+    dry_run_value = (
+        dry_run_override
+        if dry_run_override is not None
+        else bool(values.get("-DRYRUN-", True))
+    )
+
+    if not sender_value and not dry_run_value:
+        sg.popup_error("Informe o remetente (From).")
+        return None
+
+    smtp_user_input = str(values.get("-SMTPUSER-", "")).strip()
+    smtp_user_value = smtp_user_input or sender_value
+
+    password_input = str(values.get("-SMTPPASS-", "")).strip()
+    env_password = os.getenv("SMTP_PASSWORD", "")
+    password_to_use = password_input or env_password
+
+    if not dry_run_value and not password_to_use:
+        sg.popup_error(
+            "Informe a senha SMTP ou defina a variável de ambiente SMTP_PASSWORD."
+        )
+        return None
+
+    log_level_value = str(values.get("-LOGLEVEL-", "") or "INFO").strip() or "INFO"
+
+    return RunParams(
+        input_path=excel_path,
+        sheet=sheet_value,
+        sender=sender_value,
+        smtp_user=smtp_user_value or sender_value,
+        smtp_password=password_to_use,
+        subject_template=subject_template,
+        body_html=body_html,
+        dry_run=dry_run_value,
+        log_level=log_level_value,
+    )
+
+
+def _start_worker(window: sg.Window, params: RunParams, *, mode: str) -> None:
+    if run_program is None:
+        sg.popup_error("Função de execução indisponível. Verifique a instalação.")
+        return
+
+    global worker_thread  # pylint: disable=global-statement
+
+    action_label = "prévia" if mode == "preview" else "envio"
+    append_log(window, f"\n[INFO] Iniciando {action_label}\n")
+
+    sheet_display = params.sheet or "(padrão)"
+    sender_display = params.sender or "(não informado)"
+    smtp_user_display = params.smtp_user or sender_display
+    mode_display = "Dry-run (sem envio real)" if params.dry_run else "Envio real"
+    password_line = "[INFO] Senha: ********" if params.smtp_password else "[INFO] Senha: (não informada)"
+
+    append_log(
+        window,
+        "[INFO] Planilha: {} | Sheet: {} | Remetente: {} | SMTP User: {}\n".format(
+            params.input_path,
+            sheet_display,
+            sender_display,
+            smtp_user_display,
+        ),
+    )
+    append_log(window, f"[INFO] Assunto: {params.subject_template}\n")
+    append_log(window, f"[INFO] Modo: {mode_display}\n")
+    append_log(window, password_line + "\n")
+    append_log(window, f"[INFO] Log level: {params.log_level or 'INFO'}\n")
+
+    def _run() -> None:  # pragma: no cover - integração com UI
+        try:
+            result_code = run_program(params)
+        except Exception as exc:  # pylint: disable=broad-except
+            log_queue.put(("ERROR", f"Falha durante a execução: {exc}\n"))
+        else:
+            log_queue.put(("RESULT", f"{mode}:{result_code}"))
+
+    worker_thread = threading.Thread(target=_run, daemon=True)
+    worker_thread.start()
+
+
+def _show_preview(params: RunParams) -> bool:
+    if load_contacts is None:
+        sg.popup_error("Função de carregamento indisponível. Verifique a instalação.")
+        return False
+
+    try:
+        dataframe = load_contacts(params.input_path, params.sheet)
+    except Exception as exc:  # pylint: disable=broad-except
+        sg.popup_error(f"Erro ao carregar planilha: {exc}")
+        return False
+
+    dataframe = _normalize_headers(dataframe)
+
+    missing_required = sorted(REQUIRED_COLUMNS - set(dataframe.columns))
+    if missing_required:
+        formatted = ", ".join(missing_required)
+        sg.popup_error(
+            "Planilha inválida. Colunas obrigatórias ausentes: " f"{formatted}."
+        )
+        return False
+
+    placeholders = _extract_placeholders(params.subject_template, params.body_html)
+    missing_placeholders = sorted(placeholders - set(dataframe.columns))
+    if missing_placeholders:
+        formatted = ", ".join(missing_placeholders)
+        sg.popup_error(
+            "Planilha inválida. Colunas ausentes para placeholders: "
+            f"{formatted}."
+        )
+        return False
+
+    if dataframe.empty:
+        sg.popup(
+            "Planilha carregada, mas não há registros para pré-visualizar.",
+            title="Prévia",
+        )
+        return False
+
+    previews: list[str] = []
+    records = dataframe.to_dict(orient="records")
+    for index, row in enumerate(records[:3], start=1):
+        try:
+            rendered_subject, rendered_body = render(
+                params.subject_template, params.body_html, row
+            )
+        except TemplateRenderingError as exc:
+            sg.popup_error(str(exc))
+            return False
+
+        plain_body = re.sub(r"<[^>]+>", "", rendered_body)
+        plain_body = re.sub(r"\s+", " ", plain_body).strip()
+        plain_body = plain_body[:200]
+
+        previews.append(
+            "Amostra {index}\nAssunto: {subject}\nCorpo: {body}".format(
+                index=index, subject=rendered_subject, body=plain_body
+            )
+        )
+
+    preview_text = "\n\n".join(previews)
+    sg.popup_scrolled(preview_text, title="Prévia", non_blocking=False)
+    return True
 
 
 # -------- UI --------
@@ -189,87 +359,7 @@ while True:
         excel_path = values["-EXCEL-"].strip()
         _update_sheet_combo(window, excel_path)
 
-    if event == "-PREVIEW-":
-        excel = values["-EXCEL-"].strip()
-        if not excel:
-            sg.popup_error("Selecione a planilha (XLSX/CSV).")
-            continue
-
-        subject_template = values["-SUBJECT-"].strip()
-        if not subject_template:
-            sg.popup_error("Informe o assunto (template).")
-            continue
-
-        body_html_path = values["-HTML-"].strip()
-        body_html = _read_html_template(body_html_path)
-        if body_html is None:
-            continue
-
-        sheet_value = (values.get("-SHEET-") or "").strip() or None
-
-        try:
-            dataframe = load_contacts(Path(excel), sheet=sheet_value)
-        except Exception as exc:  # pylint: disable=broad-except
-            sg.popup_error(f"Erro ao carregar planilha: {exc}")
-            continue
-
-        dataframe = _normalize_headers(dataframe)
-
-        missing_required = sorted(REQUIRED_COLUMNS - set(dataframe.columns))
-        if missing_required:
-            formatted = ", ".join(missing_required)
-            sg.popup_error(
-                "Planilha inválida. Colunas obrigatórias ausentes: " f"{formatted}."
-            )
-            continue
-
-        placeholders = _extract_placeholders(subject_template, body_html)
-        missing_placeholders = sorted(placeholders - set(dataframe.columns))
-        if missing_placeholders:
-            formatted = ", ".join(missing_placeholders)
-            sg.popup_error(
-                "Planilha inválida. Colunas ausentes para placeholders: "
-                f"{formatted}."
-            )
-            continue
-
-        if dataframe.empty:
-            sg.popup(
-                "Planilha carregada, mas não há registros para pré-visualizar.",
-                title="Prévia",
-            )
-            continue
-
-        previews: list[str] = []
-        success = True
-        records = dataframe.to_dict(orient="records")
-        for index, row in enumerate(records[:3], start=1):
-            try:
-                rendered_subject, rendered_body = render(
-                    subject_template, body_html, row
-                )
-            except TemplateRenderingError as exc:
-                sg.popup_error(str(exc))
-                success = False
-                break
-
-            plain_body = re.sub(r"<[^>]+>", "", rendered_body)
-            plain_body = re.sub(r"\s+", " ", plain_body).strip()
-            plain_body = plain_body[:200]
-
-            previews.append(
-                "Amostra {index}\nAssunto: {subject}\nCorpo: {body}".format(
-                    index=index, subject=rendered_subject, body=plain_body
-                )
-            )
-
-        if not success:
-            continue
-
-        preview_text = "\n\n".join(previews)
-        sg.popup_scrolled(preview_text, title="Prévia", non_blocking=False)
-
-    if event == "-RUN-":
+    if event in ("-PREVIEW-", "-RUN-"):
         if IMPORT_ERROR is not None:
             sg.popup_error(
                 "Não foi possível importar o módulo email_sender. "
@@ -282,62 +372,16 @@ while True:
             sg.popup_error("Já existe um envio em andamento. Aguarde a finalização.")
             continue
 
-        excel = values["-EXCEL-"].strip()
-        if not excel:
-            sg.popup_error("Selecione a planilha (XLSX/CSV).")
+        dry_run_override = True if event == "-PREVIEW-" else None
+        params = _prepare_run_params(values, dry_run_override=dry_run_override)
+        if params is None:
             continue
 
-        sender = values["-SENDER-"].strip()
-        if not sender:
-            sg.popup_error("Informe o remetente (From).")
+        if event == "-PREVIEW-" and not _show_preview(params):
             continue
 
-        subject_template = values["-SUBJECT-"].strip()
-        if not subject_template:
-            sg.popup_error("Informe o assunto (template).")
-            continue
-
-        body_html_path = values["-HTML-"].strip()
-        body_html = _read_html_template(body_html_path)
-        if body_html is None:
-            continue
-
-        password_value = values["-SMTPPASS-"].strip()
-        env_password = os.getenv("SMTP_PASSWORD")
-
-        params = RunParams(
-            input_path=Path(excel),
-            sender=sender,
-            subject_template=subject_template,
-            body_html=body_html,
-            sheet=(values.get("-SHEET-") or "").strip() or None,
-            smtp_user=values["-SMTPUSER-"].strip() or None,
-            smtp_password=password_value or env_password,
-            dry_run=values["-DRYRUN-"],
-            log_level=values["-LOGLEVEL-"] or None,
-        )
-
-        append_log(window, "\n[INFO] Iniciando envio\n")
-        append_log(
-            window,
-            "[INFO] Planilha: {} | Sheet: {} | Remetente: {} | Assunto: {}\n".format(
-                excel,
-                (values.get("-SHEET-") or "").strip() or "(padrão)",
-                sender,
-                subject_template,
-            ),
-        )
-
-        def _run() -> None:
-            try:
-                result_code = run_program(params)  # type: ignore[misc]
-            except Exception as exc:  # pylint: disable=broad-except
-                log_queue.put(("ERROR", f"Falha durante a execução: {exc}\n"))
-            else:
-                log_queue.put(("RESULT", str(result_code)))
-
-        worker_thread = threading.Thread(target=_run, daemon=True)
-        worker_thread.start()
+        mode = "preview" if event == "-PREVIEW-" else "run"
+        _start_worker(window, params, mode=mode)
 
     try:
         while True:
@@ -348,7 +392,17 @@ while True:
                 append_log(window, payload, tag="ERR")
                 worker_thread = None
             elif tag == "RESULT":
-                append_log(window, f"\n[INFO] Finalizado com código {payload}\n")
+                mode_label, separator, code = payload.partition(":")
+                if separator:
+                    description = "Prévia" if mode_label == "preview" else "Execução"
+                    result_code = code
+                else:
+                    description = "Execução"
+                    result_code = mode_label
+                append_log(
+                    window,
+                    f"\n[INFO] {description} finalizada com código {result_code}\n",
+                )
                 worker_thread = None
     except queue.Empty:
         pass


### PR DESCRIPTION
## Summary
- expose a public `RunParams` dataclass and `run_program` entry point in `email_sender`, along with re-exported `load_contacts`, so the UI can drive the core logic directly
- update the PySimpleGUI front-end to build `RunParams`, run the email workflow on a worker thread for both preview and send actions, and stream logs to the UI without leaking SMTP credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e082291acc8324ab5e77bd1393c307