### PR TITLE
Enhance GUI ergonomics with progress feedback

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -188,6 +188,12 @@ def run_program(params: RunParams) -> int:
 
     processed_count = len(sampled_records)
 
+    logging.info(
+        "Processando %s contatos (total na planilha: %s)",
+        processed_count,
+        total_contacts,
+    )
+
     smtp_user_value = params.smtp_user.strip()
     smtp_user = smtp_user_value or params.sender
 


### PR DESCRIPTION
## Summary
- disable all GUI inputs during preview/sending, show an indeterminate progress bar and live sent/total counter based on log updates
- add subject-from-file support, HTML quick preview, and friendlier validation messages while remembering last used paths in a JSON settings file
- log the total number of contacts to process so the GUI can surface progress information

## Testing
- python -m compileall gui.py email_sender.py

------
https://chatgpt.com/codex/tasks/task_e_68e0848448588324bceaaa15742001ce