### PR TITLE
Use default filter in example email template

### DIFF
--- a/examples/corpo_exemplo.html
+++ b/examples/corpo_exemplo.html
@@ -27,7 +27,7 @@
     </div>
 
     <p>Conte conosco — nossa equipe está à disposição.</p>
-    <p class="footer">Emaileria — Exemplo de corpo HTML · {{ data_envio or "" }}</p>
+    <p class="footer">Emaileria — Exemplo de corpo HTML · {{ data_envio | default('') }}</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the example email body template fallback to use the Jinja2 `default` filter so it works with `StrictUndefined`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e08896159883248e49e4765a7465f2