### PR TITLE
Add global datetime defaults to template rendering

### DIFF
--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,0 +1,36 @@
+from datetime import date, datetime
+
+from emaileria.templating import render
+
+
+def test_render_injects_default_dates() -> None:
+    subject_template = "{{ data_envio }}"
+    body_template = "{{ hora_envio }}"
+
+    subject, body = render(subject_template, body_template, {})
+
+    assert subject == date.today().strftime("%Y-%m-%d")
+    datetime.strptime(body, "%H:%M")
+
+
+def test_render_exposes_now_with_datefmt_filter() -> None:
+    subject_template = ""
+    body_template = "{{ now|datefmt('%Y-%m-%d') }}"
+
+    _, body = render(subject_template, body_template, {})
+
+    assert body == date.today().strftime("%Y-%m-%d")
+
+
+def test_render_allows_context_to_override_globals() -> None:
+    subject_template = "{{ data_envio }}"
+    body_template = "{{ hora_envio }}"
+
+    subject, body = render(
+        subject_template,
+        body_template,
+        {"data_envio": "custom", "hora_envio": "12:34"},
+    )
+
+    assert subject == "custom"
+    assert body == "12:34"


### PR DESCRIPTION
## Summary
- inject reusable global context values for dates and times when rendering templates
- register a reusable datefmt filter to format datetime and date instances
- cover the new rendering capabilities with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0899cb3788324856e71dc4c846138