### PR TITLE
Validate placeholders before running previews

### DIFF
--- a/emaileria/templating.py
+++ b/emaileria/templating.py
@@ -27,6 +27,12 @@ class TemplateRenderingError(RuntimeError):
 _env = Environment(autoescape=False, undefined=StrictUndefined)
 
 
+def extract_placeholders(text: str) -> set[str]:
+    """Extract placeholder names from template-like text."""
+
+    return set(re.findall(r"{{\s*([a-zA-Z0-9_]+)\s*}}", text or ""))
+
+
 def _datefmt(value: object, fmt: str = "%Y-%m-%d") -> str:
     if value is None:
         return ""


### PR DESCRIPTION
## Summary
- add a shared helper to extract template placeholders
- validate placeholders against spreadsheet columns in the GUI and wizard before previewing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a8b30a6483249b17372406c91b04