### PR TITLE
Add tolerant rendering mode and enhance GUI validation

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -43,6 +43,7 @@ class RunParams:
     limit: int | None = None
     offset: int | None = None
     log_level: str | None = "INFO"
+    allow_missing_fields: bool = False
 
 
 def _ensure_logs_dir() -> None:
@@ -194,6 +195,11 @@ def run_program(params: RunParams) -> int:
         total_contacts,
     )
 
+    if params.allow_missing_fields:
+        logging.info(
+            "Modo tolerante ativo: placeholders ausentes serão preenchidos com vazio."
+        )
+
     smtp_user_value = params.smtp_user.strip()
     smtp_user = smtp_user_value or params.sender
 
@@ -205,6 +211,7 @@ def run_program(params: RunParams) -> int:
                 subject_template=params.subject_template,
                 body_template=params.body_html,
                 dry_run=True,
+                allow_missing_fields=params.allow_missing_fields,
             )
         except SystemExit as exc:
             return int(exc.code or 1)
@@ -250,6 +257,7 @@ def run_program(params: RunParams) -> int:
                     body_template=params.body_html,
                     provider=provider,
                     dry_run=False,
+                    allow_missing_fields=params.allow_missing_fields,
                 )
             except SystemExit as exc:
                 return int(exc.code or 1)

--- a/emaileria/templating.py
+++ b/emaileria/templating.py
@@ -6,7 +6,9 @@ import re
 from datetime import date, datetime
 from typing import Dict, Mapping, Tuple
 
-from jinja2 import Environment, StrictUndefined, UndefinedError
+from typing import Callable
+
+from jinja2 import Environment, StrictUndefined, Undefined, UndefinedError
 
 _PLACEHOLDER_PATTERN = r"'(.+?)' is undefined"
 
@@ -24,7 +26,15 @@ class TemplateRenderingError(RuntimeError):
         super().__init__(message)
 
 
-_env = Environment(autoescape=False, undefined=StrictUndefined)
+class SoftUndefined(Undefined):
+    def _fail_with_undefined_error(self, *args, **kwargs):  # type: ignore[override]
+        return ""
+
+
+_STRICT_ENV = Environment(
+    autoescape=False, undefined=StrictUndefined, keep_trailing_newline=True
+)
+_SOFT_ENV = Environment(autoescape=False, undefined=SoftUndefined, keep_trailing_newline=True)
 
 
 def extract_placeholders(text: str) -> set[str]:
@@ -41,7 +51,8 @@ def _datefmt(value: object, fmt: str = "%Y-%m-%d") -> str:
     return str(value)
 
 
-_env.filters["datefmt"] = _datefmt
+for _environment in (_STRICT_ENV, _SOFT_ENV):
+    _environment.filters["datefmt"] = _datefmt
 
 
 def _global_context() -> Dict[str, object]:
@@ -63,20 +74,52 @@ def _extract_placeholder_name(error: UndefinedError) -> str:
 
 
 def _render_template(
-    template: str, context: Mapping[str, object], template_type: str
+    template: str,
+    context: Mapping[str, object],
+    template_type: str,
+    *,
+    environment: Environment,
 ) -> str:
     try:
-        return _env.from_string(template).render(**context)
+        return environment.from_string(template).render(**context)
     except UndefinedError as exc:  # pragma: no cover - defensive parsing
         placeholder = _extract_placeholder_name(exc)
         raise TemplateRenderingError(template_type, placeholder, exc) from exc
 
 
 def render(
-    subject_template: str, body_template: str, context: Mapping[str, object]
+    subject_template: str,
+    body_template: str,
+    context: Mapping[str, object],
+    *,
+    allow_missing: bool = False,
+    on_missing: Callable[[str], None] | None = None,
 ) -> Tuple[str, str]:
     """Render subject and body templates with the provided context."""
     merged_context: Dict[str, object] = {**_global_context(), **dict(context)}
-    subject = _render_template(subject_template, merged_context, "assunto")
-    body = _render_template(body_template, merged_context, "corpo")
+    environment = _SOFT_ENV if allow_missing else _STRICT_ENV
+
+    missing_placeholders: set[str] = set()
+    if allow_missing:
+        normalized_keys = {str(key).strip().lower() for key in merged_context}
+        used_placeholders = extract_placeholders(subject_template) | extract_placeholders(
+            body_template
+        )
+        missing_placeholders = {
+            placeholder
+            for placeholder in used_placeholders
+            if placeholder.lower() not in normalized_keys
+        }
+
+    subject = _render_template(
+        subject_template, merged_context, "assunto", environment=environment
+    )
+    body = _render_template(
+        body_template, merged_context, "corpo", environment=environment
+    )
+
+    if allow_missing and on_missing is not None:
+        for placeholder in sorted(missing_placeholders):
+            on_missing(placeholder)
+
     return subject, body


### PR DESCRIPTION
## Summary
- add a SoftUndefined-based rendering option that logs missing placeholders while continuing execution
- expose the tolerant mode in the GUI and wizard, including logging and updated validations for sends
- tighten GUI UX by requiring sender credentials for real runs and only enabling the send button after a successful preview

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a9df1e7883248e3d4e11ea14ba9c