### PR TITLE
Atualiza exemplos com instruções sobre data_envio

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Este diretório reúne um conjunto mínimo de arquivos para testar o Emaileria v
 - `assunto_exemplo.txt`: template de assunto usando o nome e a cidade do lead.
 - `corpo_exemplo.html`: template HTML com placeholders para todas as colunas da planilha.
 
+> Você pode remover `data_envio` ou usar `{{ data_envio | default('') }}`. O Emaileria também injeta `now`, `hoje`, `hora_envio` por padrão.
+
 ## Como usar
 
 1. Abra o aplicativo desejado e selecione a planilha `leads_exemplo.xlsx` quando for solicitado.

--- a/examples/readme/corpo_exemplo.html
+++ b/examples/readme/corpo_exemplo.html
@@ -1,0 +1,1 @@
+<p class="footer">Emaileria — Exemplo · {{ data_envio | default('') }}</p>


### PR DESCRIPTION
## Summary
- atualiza o snippet de rodapé usado na documentação para exibir `data_envio` de forma opcional
- documenta no README de exemplos como usar as variáveis injetadas automaticamente

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ac46f9888324b7c6f5ddfbaa3641