### PR TITLE
feat: add GUI validation flow and core API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ env/
 # PyInstaller
 *.manifest
 *.spec
+!emaileria.spec
 
 # Installer logs
 pip-log.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: gui build-win build-mac
+
+PYTHON ?= python
+PYINSTALLER ?= pyinstaller
+
+GUI_ENTRY := gui.py
+SPEC_FILE := emaileria.spec
+
+gui:
+	$(PYTHON) $(GUI_ENTRY)
+
+build-win:
+	$(PYINSTALLER) --clean --onefile --noconsole $(SPEC_FILE)
+
+build-mac:
+	$(PYINSTALLER) --clean --onefile --windowed $(SPEC_FILE)

--- a/emaileria.spec
+++ b/emaileria.spec
@@ -1,0 +1,50 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""Configuração do PyInstaller para empacotar a GUI do Emaileria."""
+
+from pathlib import Path
+
+from PyInstaller.building.build_main import Analysis, EXE, PYZ
+
+block_cipher = None
+
+icon_candidate = Path("assets/emaileria.ico")
+icon_file = str(icon_candidate) if icon_candidate.is_file() else None
+
+
+a = Analysis(
+    ['gui.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name='emaileria',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_file,
+)

--- a/emaileria_wizard.py
+++ b/emaileria_wizard.py
@@ -24,7 +24,7 @@ from emaileria.templating import TemplateRenderingError, extract_placeholders, r
 
 
 CONTACT_PATTERNS = ("*.csv", "*.CSV", "*.xlsx", "*.XLSX")
-TEMPLATE_PATTERNS = ("*.html", "*.HTML", "*.htm", "*.HTM", "*.j2", "*.J2")
+TEMPLATE_PATTERNS = ("*.html", "*.HTML", "*.htm", "*.HTM", "*.j2", "*.J2", "*.txt", "*.TXT")
 REQUIRED_COLUMNS = ("email", "tratamento", "nome")
 DEFAULT_INTERVAL = 0.75
 MAX_ATTEMPTS = 3
@@ -506,6 +506,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             if child.is_dir():
                 contact_dirs.append(child)
 
+    examples_dir = Path.cwd() / "examples"
+    readme_dir = examples_dir / "readme"
+    for directory in (examples_dir, readme_dir):
+        if directory.exists() and directory.is_dir():
+            contact_dirs.append(directory)
+
     contact_prompt = "\nSelecione o arquivo de contatos detectado ou informe o caminho manual:"
     contact_path = pick_from_list_or_path(
         contact_prompt, gather_candidates(CONTACT_PATTERNS, contact_dirs)
@@ -542,6 +548,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     templates_dir = Path.cwd() / "templates"
     if templates_dir.exists() and templates_dir.is_dir():
         template_dirs.append(templates_dir)
+
+    for directory in (examples_dir, readme_dir):
+        if directory.exists() and directory.is_dir():
+            template_dirs.append(directory)
 
     template_prompt = "Selecione o template de e-mail (HTML/Jinja2) ou informe o caminho manual:"
     template_path = pick_from_list_or_path(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 openpyxl
 Jinja2
 certifi
+PySimpleGUI


### PR DESCRIPTION
## Summary
- integrate the GUI directly with the core sender module, adding validation/preview, rate limiting controls, cancellation and settings persistence
- refactor the email sender core to expose a stable RunParams API with CC/BCC/Reply-To support, interval handling, and CSV/SQLite logging
- add packaging assets for PyInstaller builds, refresh examples/README guidance, and update dependencies
- ensure CC/BCC headers are populated on outgoing messages and drop the GUI screenshot asset as requested

## Testing
- python -m compileall emaileria gui.py email_sender.py emaileria_wizard.py

------
https://chatgpt.com/codex/tasks/task_e_68e1af5e39848324b0356724dea7c88e